### PR TITLE
✨ 게임 랭킹 1등일 때 3등까지 보이게 수정

### DIFF
--- a/src/components/game-over/GameOverModal.vue
+++ b/src/components/game-over/GameOverModal.vue
@@ -67,11 +67,23 @@ const filterRankingsForDisplay = (rankings, latestRanking) => {
     (rank) => rank.rank === latestRanking.rank + 1
   );
 
+  const rankPlusTwo = rankings.find(
+    (rank) => rank.rank === latestRanking.rank + 2
+  );
+
   if (!rankPlusOne) {
     return [
       rankMinusOne,
       { ...latestRanking, isHighlighted: true },
       { isLastPlace: true },
+    ].filter(Boolean);
+  }
+
+  if (latestRanking.rank === 1 && rankPlusTwo) {
+    return [
+      { ...latestRanking, isHighlighted: true },
+      rankPlusOne,
+      rankPlusTwo,
     ].filter(Boolean);
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #144

## 📝작업 내용

> 게임 랭킹 1등일 때 3등까지 보이게 수정

### 스크린샷 (선택)
<img width="1499" alt="image" src="https://github.com/user-attachments/assets/6a33a3cd-99f0-45d2-a4d1-e3c5e8a9a692" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
